### PR TITLE
Change '#pragma once' to '#include' guards

### DIFF
--- a/static_todo.hpp
+++ b/static_todo.hpp
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef CPP_STATIC_TODO
+#define CPP_STATIC_TODO
 
 // Returns the year from the current build date
 constexpr int current_build_year() {
@@ -56,3 +57,5 @@ constexpr int current_build_month() {
                       (current_build_year() < year ||                                              \
                           (current_build_year() == year && current_build_month() < month)),        \
         "FIXME: " msg)
+
+#endif


### PR DESCRIPTION
#pragma once is not guaranteed to be supported on all compilers. (https://en.wikipedia.org/wiki/Pragma_once#Portability). As to increase portability, I've changed to '#include' guards.