### PR TITLE
Fix behaviour, update syntax and write (static) tests. 

### DIFF
--- a/static_todo.hpp
+++ b/static_todo.hpp
@@ -1,30 +1,54 @@
 #pragma once
 
-// Returns the year from the current build date
-constexpr int current_build_year() {
-    // exemple: "Nov 27 2018"
-    const char *year = __DATE__;
+#ifndef __DATE__
+#error "__DATE__ is not defined, which is required for TODO_BEFORE"
+#endif
 
-    // skip the 2 first spaces
-    int nbSpaces = 0;
-    while (nbSpaces < 2) {
-        if (*year == ' ') {
-            nbSpaces++;
+namespace static_todo {
+constexpr const char months[12][4]{
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+
+consteval bool is_whitespace(char c) { return c == ' ' || c == '\t'; }
+consteval bool is_null(char c) { return c == '\0'; }
+
+consteval int year_string_to_int(const char *year) {
+    return (year[0] - '0') * 1000 + (year[1] - '0') * 100 + (year[2] - '0') * 10 + (year[3] - '0');
+}
+
+consteval int get_year_from_string(const char *date) {
+    const char *year = date;
+
+    // Walk over the first two words and point at the start of the year
+    // NB There could be multiple spaces between the words!
+    int num_words = 0;
+    bool was_prev_char_space = false;
+    while (num_words < 2) {
+        if (is_whitespace(*year)) {
+            if (!was_prev_char_space) {
+                num_words++;
+            }
+            was_prev_char_space = true;
+        } else {
+            was_prev_char_space = false;
         }
         year++;
     }
 
-    return (year[0] - '0') * 1000 + (year[1] - '0') * 100 + (year[2] - '0') * 10 + (year[3] - '0');
+    return year_string_to_int(year);
 }
 
-// Returns the month number (1..12) from the current build date
-constexpr int current_build_month() {
-    constexpr const char months[12][4]{
-        "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+consteval bool is_a_month(const char *month) {
+    for (int i = 0; i < 12; i++) {
+        if (month[0] == months[i][0] && month[1] == months[i][1] && month[2] == months[i][2] &&
+            is_null(month[3])) {
+            return true;
+        }
+    }
+    return false;
+}
 
-    // exemple: "Nov 27 2018"
-    constexpr const char date[] = __DATE__;
-
+// Returns the month number (1..12) from an input string
+consteval int get_month_from_string(const char *date) {
     // find matching month
     for (int i = 0; i < 12; i++) {
         const char *m = months[i];
@@ -32,9 +56,15 @@ constexpr int current_build_month() {
             return i + 1;
         }
     }
-
-    return 0; // will be caught by the static_assert() check on month value
+    return 0;
 }
+
+consteval bool is_date_before(const char *date, int year, int month) {
+    return get_year_from_string(date) < year ||
+           (get_year_from_string(date) == year && get_month_from_string(date) < month);
+}
+
+} // namespace static_todo
 
 /// TODO_BEFORE() inserts a compilation "time bomb" that will trigger a "TODO" build error a soon as
 /// the given date is reached.
@@ -45,14 +75,20 @@ constexpr int current_build_month() {
 /// Example:
 ///     TODO_BEFORE(01, 2019, "refactor to use std::optional<> once we compile in C++17 mode");
 #define TODO_BEFORE(month, year, msg)                                                              \
-    static_assert((year >= 2018 && month > 0 && month <= 12) &&                                    \
-                      (current_build_year() < year ||                                              \
-                          (current_build_year() == year && current_build_month() < month)),        \
+    static_assert(                                                                                 \
+        static_todo::is_a_month(#month), "Enter a month in the format Jan, Feb, Dec, etc.");       \
+    static_assert(                                                                                 \
+        static_todo::is_date_before(__DATE__, year, static_todo::get_month_from_string(#month)),   \
         "TODO: " msg)
 
-/// FIXME_BEFORE() works the same way than TODO_BEFORE() but triggers a "FIXME" error instead
+/// FIXME_BEFORE() works the same way than TODO_BEFORE() but triggers a "FIXME" error
+/// instead
 #define FIXME_BEFORE(month, year, msg)                                                             \
-    static_assert((year >= 2018 && month > 0 && month <= 12) &&                                    \
-                      (current_build_year() < year ||                                              \
-                          (current_build_year() == year && current_build_month() < month)),        \
-        "FIXME: " msg)
+    static_assert(                                                                                 \
+        static_todo::is_a_month(#month), "Enter a month in the format Jan, Feb, Dec, etc.");       \
+    static_assert(                                                                                 \
+        static_todo::is_date_before(__DATE__, year, static_todo::get_month_from_string(#month)),   \
+        "TODO: " msg)
+
+// Include tests here, so they are compiled with the rest of the code
+#include "static_todo.tests.hpp"

--- a/static_todo.tests.hpp
+++ b/static_todo.tests.hpp
@@ -1,0 +1,40 @@
+//
+// Created by Jamie Pond on 09/12/2022.
+//
+
+// Tests for the static_todo.hpp header
+// These are all static assertions, so if they fail to compile, the test has failed!
+namespace static_todo {
+static_assert(is_whitespace(' '));
+static_assert(is_whitespace('\t'));
+static_assert(!is_whitespace('a'));
+
+static_assert(year_string_to_int("2018") == 2018);
+static_assert(year_string_to_int("2345") == 2345);
+
+static_assert(get_year_from_string("Jan  1 2018") == 2018);
+static_assert(get_year_from_string("Dec 1 2022") == 2022);
+static_assert(get_year_from_string("December \t 1st 2022") == 2022);
+static_assert(get_year_from_string("December 1st 2022") == 2022);
+static_assert(get_year_from_string("1st December 2022") == 2022);
+static_assert(get_year_from_string("1s t December 2022") != 2022);  // breaks! four total spaces.
+
+static_assert(is_a_month("Jan"));
+static_assert(is_a_month("Feb"));
+static_assert(is_a_month("Mar"));
+static_assert(!is_a_month("April"));  // Must be 3 chars
+static_assert(is_a_month("May"));
+static_assert(!is_a_month("jun"));  // Must be title case
+
+static_assert(get_month_from_string("Jan  1 2018") == 1);
+static_assert(get_month_from_string("Feb 1 2022") == 2);
+static_assert(get_month_from_string("Mar \t 1st 2022") == 3);
+static_assert(get_month_from_string("Apr 1st 2022") == 4);
+static_assert(get_month_from_string("Nov 1st 2022") == 11);
+static_assert(get_month_from_string("Dec 1st 2022") == 12);
+
+static_assert(is_date_before("Jan 1 2017", 2018, 1));
+static_assert(is_date_before("Jan 1 2018", 2018, 2));
+static_assert(is_date_before("Mar 31 1901", 1902, 2));
+static_assert(is_date_before("Feb 31 1902", 1902, 3));
+}  // namespace static_todo


### PR DESCRIPTION
Initially was incorrectly reporting the date because `__DATE__` was returning a string with an extra space, so I've fixed that, tested everything and updated the syntax to the more readable `TODO_BEFORE(Jan, 2023, "Please do me!");`